### PR TITLE
Fixed text overflow in dropdown menu (#26622)

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1232,6 +1232,8 @@ img.ui.avatar,
 
 .ui.menu .ui.dropdown.item .menu .item {
   width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ui.dropdown .menu > .item > .floating.label {


### PR DESCRIPTION
Fixes #26622

![image](https://github.com/POPSuL/gitea/assets/683358/765d39cb-77c2-4eb4-ad3f-7d84adacfe4d)
